### PR TITLE
dechex may return incorrect ecid

### DIFF
--- a/addDevice.php
+++ b/addDevice.php
@@ -31,7 +31,7 @@
 		}
 		
 		if(ctype_digit($_POST['ecid'])) { // Client provided a non-hex ECID. Convert it for them.
-			$ecid = strtoupper(dechex($_POST['ecid']));
+			$ecid = strtoupper(base_convert($_POST['ecid'], 10, 16));
 		} elseif(ctype_xdigit($_POST['ecid'])) { // Client provided a hex ECID, just assign the variable.
 			$ecid = strtoupper($_POST['ecid']);
 		} else {


### PR DESCRIPTION
Below is dechex description on php.net (http://php.net/manual/en/function.dechex.php)

string dechex ( int $number )

Returns a string containing a hexadecimal representation of the given unsigned number argument. 

The largest number that can be converted is PHP_INT_MAX * 2 + 1 (or -1): on 32-bit platforms, this will be 4294967295 in decimal, which results in dechex() returning ffffffff.